### PR TITLE
Use the max_digits10 constant rather than the digits10 constant when …

### DIFF
--- a/include/mp++/detail/mpfr.hpp
+++ b/include/mp++/detail/mpfr.hpp
@@ -51,10 +51,10 @@ struct mpfr_raii {
 using smart_mpfr_str = std::unique_ptr<char, void (*)(char *)>;
 
 // A couple of sanity checks when constructing temporary mpfrs/mpfs from long double.
-static_assert(std::numeric_limits<long double>::digits10 < std::numeric_limits<int>::max() / 4, "Overflow error.");
-static_assert(std::numeric_limits<long double>::digits10 * 4 < std::numeric_limits<::mpfr_prec_t>::max(),
+static_assert(std::numeric_limits<long double>::max_digits10 < std::numeric_limits<int>::max() / 4, "Overflow error.");
+static_assert(std::numeric_limits<long double>::max_digits10 * 4 < std::numeric_limits<::mpfr_prec_t>::max(),
               "Overflow error.");
-static_assert(std::numeric_limits<long double>::digits10 * 4 < std::numeric_limits<::mp_bitcnt_t>::max(),
+static_assert(std::numeric_limits<long double>::max_digits10 * 4 < std::numeric_limits<::mp_bitcnt_t>::max(),
               "Overflow error.");
 
 // Machinery to call automatically mpfr_free_cache() at program shutdown,

--- a/include/mp++/integer.hpp
+++ b/include/mp++/integer.hpp
@@ -549,7 +549,7 @@ union integer_union {
                                     + std::to_string(x));
         }
         // NOTE: static checks for overflows are done in mpfr.hpp.
-        constexpr int d2 = std::numeric_limits<long double>::digits10 * 4;
+        constexpr int d2 = std::numeric_limits<long double>::max_digits10 * 4;
         MPPP_MAYBE_TLS mpfr_raii mpfr(static_cast<::mpfr_prec_t>(d2));
         MPPP_MAYBE_TLS mpz_raii tmp;
         ::mpfr_set_ld(&mpfr.m_mpfr, x, MPFR_RNDN);
@@ -1590,7 +1590,7 @@ private:
     template <typename T, enable_if_t<std::is_same<T, long double>::value, int> = 0>
     static std::pair<bool, T> mpz_float_conversion(const mpz_struct_t &m)
     {
-        constexpr int d2 = std::numeric_limits<long double>::digits10 * 4;
+        constexpr int d2 = std::numeric_limits<long double>::max_digits10 * 4;
         MPPP_MAYBE_TLS mpfr_raii mpfr(static_cast<::mpfr_prec_t>(d2));
         ::mpfr_set_z(&mpfr.m_mpfr, &m, MPFR_RNDN);
         return std::make_pair(true, ::mpfr_get_ld(&mpfr.m_mpfr, MPFR_RNDN));

--- a/include/mp++/rational.hpp
+++ b/include/mp++/rational.hpp
@@ -296,7 +296,7 @@ private:
                                     + std::to_string(x));
         }
         // NOTE: static checks for overflows are done in mpfr.hpp.
-        constexpr int d2 = std::numeric_limits<long double>::digits10 * 4;
+        constexpr int d2 = std::numeric_limits<long double>::max_digits10 * 4;
         MPPP_MAYBE_TLS mpfr_raii mpfr(static_cast<::mpfr_prec_t>(d2));
         MPPP_MAYBE_TLS mpf_raii mpf(static_cast<::mp_bitcnt_t>(d2));
         MPPP_MAYBE_TLS mpq_raii mpq;
@@ -779,7 +779,7 @@ private:
     template <typename T, enable_if_t<std::is_same<T, long double>::value, int> = 0>
     std::pair<bool, T> dispatch_conversion() const
     {
-        constexpr int d2 = std::numeric_limits<long double>::digits10 * 4;
+        constexpr int d2 = std::numeric_limits<long double>::max_digits10 * 4;
         MPPP_MAYBE_TLS mpfr_raii mpfr(static_cast<::mpfr_prec_t>(d2));
         MPPP_MAYBE_TLS mpf_raii mpf(static_cast<::mp_bitcnt_t>(d2));
         ::mpf_set_q(&mpf.m_mpf, get_mpq_view());


### PR DESCRIPTION
…reasoning about the bitwidth of long double.