### PR TITLE
Disable all move operations from mpz_t/mpq_t on MSVC, regardless of t…

### DIFF
--- a/include/mp++/integer.hpp
+++ b/include/mp++/integer.hpp
@@ -697,7 +697,7 @@ union integer_union {
     {
         dispatch_mpz_ctor(n);
     }
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
     // Move ctor from mpz_t.
     explicit integer_union(::mpz_t &&n)
     {
@@ -1240,7 +1240,7 @@ public:
      * @param n the input GMP integer.
      */
     explicit integer(const ::mpz_t n) : m_int(n) {}
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
     /// Move constructor from \p mpz_t.
     /**
      * This constructor will initialize \p this with the value of the GMP integer \p n, transferring the state
@@ -1259,8 +1259,7 @@ public:
      *
      * .. note::
      *
-     *    Due to a compiler bug, this constructor is not available on Microsoft Visual Studio
-     *    versions earlier than 14.1 (Visual Studio 2017).
+     *    Due to a compiler bug, this constructor is not available on Microsoft Visual Studio.
      * \endrststar
      *
      * @param n the input GMP integer.
@@ -1365,7 +1364,7 @@ public:
         }
         return *this;
     }
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
     /// Move assignment from \p mpz_t.
     /**
      * This assignment operator will move into \p this the GMP integer \p n. The storage type of \p this
@@ -1385,8 +1384,7 @@ public:
      *
      * .. note::
      *
-     *    Due to a compiler bug, this operator is not available on Microsoft Visual Studio
-     *    versions earlier than 14.1 (Visual Studio 2017).
+     *    Due to a compiler bug, this operator is not available on Microsoft Visual Studio.
      * \endrststar
      *
      * @param n the input GMP integer.

--- a/include/mp++/rational.hpp
+++ b/include/mp++/rational.hpp
@@ -492,7 +492,7 @@ public:
      * @param q the input GMP rational.
      */
     explicit rational(const ::mpq_t q) : m_num(mpq_numref(q)), m_den(mpq_denref(q)) {}
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
     /// Move constructor from \p mpq_t.
     /**
      * This constructor will move the numerator and denominator of the GMP rational \p q into \p this.
@@ -512,8 +512,7 @@ public:
      *
      * .. note::
      *
-     *    Due to a compiler bug, this constructor is not available on Microsoft Visual Studio
-     *    versions earlier than 14.1 (Visual Studio 2017).
+     *    Due to a compiler bug, this constructor is not available on Microsoft Visual Studio.
      * \endrststar
      *
      * @param q the input GMP rational.
@@ -604,7 +603,7 @@ public:
         m_den = mpq_denref(q);
         return *this;
     }
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
     /// Move assignment from \p mpq_t.
     /**
      * This assignment operator will move the GMP rational \p q into \p this.
@@ -627,8 +626,7 @@ public:
      *
      * .. note::
      *
-     *    Due to a compiler bug, this operator is not available on Microsoft Visual Studio
-     *    versions earlier than 14.1 (Visual Studio 2017).
+     *    Due to a compiler bug, this operator is not available on Microsoft Visual Studio.
      * \endrststar
      *
      * @param q the input GMP rational.

--- a/test/integer_basic.cpp
+++ b/test/integer_basic.cpp
@@ -355,7 +355,7 @@ TEST_CASE("mpz_t copy constructor")
     tuple_for_each(sizes{}, mpz_copy_ctor_tester{});
 }
 
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
 
 struct mpz_move_ctor_tester {
     template <typename S>
@@ -547,7 +547,7 @@ TEST_CASE("mpz_t copy assignment")
     tuple_for_each(sizes{}, mpz_copy_ass_tester{});
 }
 
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
 
 struct mpz_move_ass_tester {
     template <typename S>

--- a/test/rational_basic.cpp
+++ b/test/rational_basic.cpp
@@ -418,7 +418,7 @@ TEST_CASE("mpq_t copy constructor")
     tuple_for_each(sizes{}, mpq_copy_ctor_tester{});
 }
 
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
 
 struct mpq_move_ctor_tester {
     template <typename S>
@@ -838,7 +838,7 @@ TEST_CASE("mpq_t copy assignment")
     tuple_for_each(sizes{}, mpq_copy_ass_tester{});
 }
 
-#if !defined(_MSC_VER) || (_MSC_VER > 1900)
+#if !defined(_MSC_VER)
 
 struct mpq_move_ass_tester {
     template <typename S>


### PR DESCRIPTION
…he version.