### PR TITLE
Adding functions to real128

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,7 @@
     "files.exclude": {
         "**/.git": true,
         "build*": true,
-        "doc/doxygen/html/": true,
-        "doc/doxygen/latex/": true,
-        "doc/doxygen/xml/": true,
-        "doc/sphinx/_build/": true
+        "doc/doxygen/html/": true
     },
     "files.associations": {
         "cmath": "cpp"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
         "doc/doxygen/latex/": true,
         "doc/doxygen/xml/": true,
         "doc/sphinx/_build/": true
+    },
+    "files.associations": {
+        "cmath": "cpp"
     }
 }

--- a/doc/sphinx/real128.rst
+++ b/doc/sphinx/real128.rst
@@ -122,12 +122,36 @@ Trigonometry
 .. doxygengroup:: real128_trig
    :content-only:
 
+.. real128_hyper:
+
+Hyperbolic functions
+~~~~~~~~~~~~~~~~~~~~
+
+.. doxygengroup:: real128_hyper
+   :content-only:
+
 .. _real128_logexp:
 
 Logarithms and exponentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. doxygengroup:: real128_logexp
+   :content-only:
+
+.. _real128_gamma:
+
+Gamma functions
+~~~~~~~~~~~~~~~
+
+.. doxygengroup:: real128_gamma
+   :content-only:
+
+.. _real128_miscfuncts:
+
+Miscellaneous functions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygengroup:: real128_miscfuncts
    :content-only:
 
 .. _real128_io:

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -1108,7 +1108,7 @@ public:
     }
     /// In-place lgamma function
     /**
-     * This method will set \p this to the value of the natural logarithm of its gamma function  
+     * This method will set \p this to the value of the natural logarithm of its gamma function.
      *
      * @return a reference to \p this.
      */
@@ -1680,7 +1680,7 @@ inline real128 atan(real128 x)
 
 /** @} */
 
-/** @defgroup real128_trig real128_trig
+/** @defgroup real128_hyper real128_hyper
  *  @{
  */
 
@@ -1749,7 +1749,6 @@ inline real128 atanh(real128 x)
 {
     return x.atanh();
 }
-
 /** @} */
 
 /** @defgroup real128_miscfuncts real128_miscfuncts
@@ -1765,7 +1764,11 @@ inline real128 erf(real128 x)
 {
     return x.erf();
 }
+/** @} */
 
+/** @defgroup real_gamma real_gamma
+ *  @{
+ */
 /// Natural logarithm of the gamma funcion
 /**
  * @param x the \link mppp::real128 real128\endlink whose lgamma will be computed.
@@ -1776,8 +1779,8 @@ inline real128 lgamma(real128 x)
 {
     return x.lgamma();
 }
-
 /** @} */
+
 /** @defgroup real128_operators real128_operators
  *  @{
  */

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -956,6 +956,46 @@ public:
     {
         return *this = ::cosq(m_value);
     }
+    /// In-place tangent.
+    /**
+     * This method will set \p this to its trigonometric tangent.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &tan()
+    {
+        return *this = ::tanq(m_value);
+    }
+    /// In-place inverse sine.
+    /**
+     * This method will set \p this to its inverse sine.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &asin()
+    {
+        return *this = ::asinq(m_value);
+    }
+    /// In-place inverse cosine.
+    /**
+     * This method will set \p this to its inverse cosine.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &acos()
+    {
+        return *this = ::acosq(m_value);
+    }
+    /// In-place inverse tangent.
+    /**
+     * This method will set \p this to its inverse trigonomotric tangent.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &atan()
+    {
+        return *this = ::atanq(m_value);
+    }
     /// In-place natural exponential function.
     /**
      * This method will set \p this to \f$ \mathrm{e} \f$ raised to the power of \p this.
@@ -1522,6 +1562,50 @@ inline real128 sin(real128 x)
 inline real128 cos(real128 x)
 {
     return x.cos();
+}
+
+/// Unary tangent.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose tangent will be computed.
+ *
+ * @return the tangent of \p x.
+ */
+inline real128 tan(real128 x)
+{
+    return x.tan();
+}
+
+/// Unary inverse sine.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose inverse sine will be computed.
+ *
+ * @return the inverse sine of \p x.
+ */
+inline real128 asin(real128 x)
+{
+    return x.asin();
+}
+
+/// Unary inverse cosine.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose inverse cosine will be computed.
+ *
+ * @return the inverse cosine of \p x.
+ */
+inline real128 acos(real128 x)
+{
+    return x.acos();
+}
+
+/// Unary inverse tangent.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose inverse tangent will be computed.
+ *
+ * @return the inverse tangent of \p x.
+ */
+inline real128 atan(real128 x)
+{
+    return x.atan();
 }
 
 /** @} */

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -1106,6 +1106,16 @@ public:
     {
         return *this = ::erfq(m_value);
     }
+    /// In-place lgamma function
+    /**
+     * This method will set \p this to the value of the natural logarithm of its gamma function  
+     *
+     * @return a reference to \p this.
+     */
+    real128 &lgamma()
+    {
+        return *this = ::lgammaq(m_value);
+    }
     /// The internal value.
     /**
      * \rststar
@@ -1754,6 +1764,17 @@ inline real128 atanh(real128 x)
 inline real128 erf(real128 x)
 {
     return x.erf();
+}
+
+/// Natural logarithm of the gamma funcion
+/**
+ * @param x the \link mppp::real128 real128\endlink whose lgamma will be computed.
+ *
+ * @return the erf of \p x.
+ */
+inline real128 lgamma(real128 x)
+{
+    return x.lgamma();
 }
 
 /** @} */

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -1766,7 +1766,7 @@ inline real128 erf(real128 x)
 }
 /** @} */
 
-/** @defgroup real_gamma real_gamma
+/** @defgroup real128_gamma real128_gamma
  *  @{
  */
 /// Natural logarithm of the gamma funcion

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -1002,6 +1002,72 @@ public:
      *
      * @return a reference to \p this.
      */
+    /// In-place hyperbolic sine.
+    /**
+     * This method will set \p this to its hyperbolic sine.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &sinh()
+    {
+        return *this = ::sinhq(m_value);
+    }
+    /// In-place hyperbolic cosine.
+    /**
+     * This method will set \p this to its hyperbolic cosine.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &cosh()
+    {
+        return *this = ::coshq(m_value);
+    }
+    /// In-place hyperbolic tangent.
+    /**
+     * This method will set \p this to its hyperbolic tangent.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &tanh()
+    {
+        return *this = ::tanhq(m_value);
+    }
+    /// In-place inverse hyperbolic sine.
+    /**
+     * This method will set \p this to its inverse hyperbolic sine.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &asinh()
+    {
+        return *this = ::asinhq(m_value);
+    }
+    /// In-place inverse hyperbolic cosine.
+    /**
+     * This method will set \p this to its inverse hyperbolic cosine.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &acosh()
+    {
+        return *this = ::acoshq(m_value);
+    }
+    /// In-place inverse hyperbolic tangent.
+    /**
+     * This method will set \p this to its inverse hyperbolic tangent.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &atanh()
+    {
+        return *this = ::atanhq(m_value);
+    }
+    /// In-place natural exponential function.
+    /**
+     * This method will set \p this to \f$ \mathrm{e} \f$ raised to the power of \p this.
+     *
+     * @return a reference to \p this.
+     */
     real128 &exp()
     {
         return *this = ::expq(m_value);
@@ -1606,6 +1672,78 @@ inline real128 acos(real128 x)
 inline real128 atan(real128 x)
 {
     return x.atan();
+}
+
+/** @} */
+
+/** @defgroup real128_trig real128_trig
+ *  @{
+ */
+
+/// Unary hyperbolic sine.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose hyperbolic sine will be computed.
+ *
+ * @return the hyperbolic sine of \p x.
+ */
+inline real128 sinh(real128 x)
+{
+    return x.sinh();
+}
+
+/// Unary hyperbolic cosine.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose hyperbolic cosine will be computed.
+ *
+ * @return the hyperbolic cosine of \p x.
+ */
+inline real128 cosh(real128 x)
+{
+    return x.cosh();
+}
+
+/// Unary hyperbolic tangent.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose hyperbolic tangent will be computed.
+ *
+ * @return the hyperbolic tangent of \p x.
+ */
+inline real128 tanh(real128 x)
+{
+    return x.tanh();
+}
+
+/// Unary inverse hyperbolic sine.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose inverse hyperbolic sine will be computed.
+ *
+ * @return the inverse hyperbolic sine of \p x.
+ */
+inline real128 asinh(real128 x)
+{
+    return x.asinh();
+}
+
+/// Unary inverse hyperbolic cosine.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose inverse hyperbolic cosine will be computed.
+ *
+ * @return the inverse hyperbolic cosine of \p x.
+ */
+inline real128 acosh(real128 x)
+{
+    return x.acosh();
+}
+
+/// Unary inverse hyperbolic tangent.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose inverse hyperbolic tangent will be computed.
+ *
+ * @return the inverse hyperbolic tangent of \p x.
+ */
+inline real128 atanh(real128 x)
+{
+    return x.atanh();
 }
 
 /** @} */

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -996,12 +996,6 @@ public:
     {
         return *this = ::atanq(m_value);
     }
-    /// In-place natural exponential function.
-    /**
-     * This method will set \p this to \f$ \mathrm{e} \f$ raised to the power of \p this.
-     *
-     * @return a reference to \p this.
-     */
     /// In-place hyperbolic sine.
     /**
      * This method will set \p this to its hyperbolic sine.

--- a/include/mp++/real128.hpp
+++ b/include/mp++/real128.hpp
@@ -996,6 +996,16 @@ public:
     {
         return *this = ::log2q(m_value);
     }
+    /// In-place error function.
+    /**
+     * This method will set \p this to the value of its error function.
+     *
+     * @return a reference to \p this.
+     */
+    real128 &erf()
+    {
+        return *this = ::erfq(m_value);
+    }
     /// The internal value.
     /**
      * \rststar
@@ -1516,6 +1526,21 @@ inline real128 cos(real128 x)
 
 /** @} */
 
+/** @defgroup real128_miscfuncts real128_miscfuncts
+ *  @{
+ */
+/// Error function.
+/**
+ * @param x the \link mppp::real128 real128\endlink whose erf will be computed.
+ *
+ * @return the erf of \p x.
+ */
+inline real128 erf(real128 x)
+{
+    return x.erf();
+}
+
+/** @} */
 /** @defgroup real128_operators real128_operators
  *  @{
  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ if(MPPP_WITH_QUADMATH)
   ADD_MPPP_TESTCASE(real128_roots)
   ADD_MPPP_TESTCASE(real128_signbit)
   ADD_MPPP_TESTCASE(real128_trig)
+  ADD_MPPP_TESTCASE(real128_hyperbolic)
   ADD_MPPP_TESTCASE(real128_erf)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ if(MPPP_WITH_QUADMATH)
   ADD_MPPP_TESTCASE(real128_roots)
   ADD_MPPP_TESTCASE(real128_signbit)
   ADD_MPPP_TESTCASE(real128_trig)
+  ADD_MPPP_TESTCASE(real128_erf)
 endif()
 
 if(MPPP_WITH_MPFR)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,7 +110,7 @@ if(MPPP_WITH_QUADMATH)
   ADD_MPPP_TESTCASE(real128_signbit)
   ADD_MPPP_TESTCASE(real128_trig)
   ADD_MPPP_TESTCASE(real128_hyperbolic)
-  ADD_MPPP_TESTCASE(real128_erf)
+  ADD_MPPP_TESTCASE(real128_miscfunctions)
 endif()
 
 if(MPPP_WITH_MPFR)

--- a/test/real128_erf.cpp
+++ b/test/real128_erf.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016-2018 Francesco Biscani (bluescarni@gmail.com)
+//
+// This file is part of the mp++ library.
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <mp++/real128.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+using namespace mppp;
+
+TEST_CASE("real128 erf")
+{
+    REQUIRE(erf(real128{}) == 0);
+    real128 x;
+    REQUIRE(x.erf() == 0);
+    x = 0;
+    REQUIRE(abs(erf(real128{"1.234"}) - real128{"0.9190394169576684157198123662625681813"}) < 1E-34);
+}

--- a/test/real128_hyperbolic.cpp
+++ b/test/real128_hyperbolic.cpp
@@ -1,0 +1,65 @@
+// Copyright 2016-2018 Francesco Biscani (bluescarni@gmail.com)
+//
+// This file is part of the mp++ library.
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <mp++/real128.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+using namespace mppp;
+
+TEST_CASE("real128 sinhcosh")
+{
+    REQUIRE(cosh(real128{}) == 1);
+    REQUIRE(sinh(real128{}) == 0);
+    real128 x;
+    REQUIRE(x.cosh() == 1);
+    REQUIRE(x.sinh() != 0);
+    x = 0;
+    REQUIRE(x.sinh() == 0);
+    REQUIRE(abs(sinh(real128{"1.234"}) - real128{"1.571908059102337379176699145503416648"}) < 1E-33);
+    REQUIRE(abs(cosh(real128{"1.234"}) - real128{"1.863033801698422589073643750256062085"}) < 1E-33);
+}
+
+TEST_CASE("real128 tanh")
+{
+    REQUIRE(tanh(real128{}) == 0);
+    real128 x;
+    REQUIRE(x.tanh() == 0);
+    x = 0;
+    REQUIRE(x.tanh() == 0);
+    REQUIRE(abs(tanh(real128{"1.234"}) - real128{"0.84373566258933019391702000004355143214"}) < 1E-33);
+}
+
+TEST_CASE("real128 inversefunctions")
+{
+    {
+        REQUIRE(acosh(real128{1}) == 0.);
+        real128 x{1};
+        REQUIRE(x.acosh() == 0.);
+        x = 1;
+        REQUIRE(x.acosh() == 0.);
+        REQUIRE(abs(acos(cos(real128{"1.234"})) - real128{"1.234"}) < 1E-33);
+    }
+    {
+        REQUIRE(asinh(real128{}) == 0.);
+        real128 x;
+        REQUIRE(x.asinh() == 0.);
+        x = 0;
+        REQUIRE(x.asinh() == 0.);
+        REQUIRE(abs(asinh(sinh(real128{"0.234"})) - real128{"0.234"}) < 1E-33);
+    }
+    {
+        REQUIRE(atanh(real128{}) == 0.);
+        real128 x;
+        REQUIRE(x.atanh() == 0.);
+        x = 0;
+        REQUIRE(x.atanh() == 0.);
+        REQUIRE(abs(atanh(tanh(real128{"0.234"})) - real128{"0.234"}) < 1E-33);
+    }
+}

--- a/test/real128_miscfunctions.cpp
+++ b/test/real128_miscfunctions.cpp
@@ -18,6 +18,13 @@ TEST_CASE("real128 erf")
     REQUIRE(erf(real128{}) == 0);
     real128 x;
     REQUIRE(x.erf() == 0);
-    x = 0;
     REQUIRE(abs(erf(real128{"1.234"}) - real128{"0.9190394169576684157198123662625681813"}) < 1E-34);
+}
+
+TEST_CASE("real128 lgamma")
+{
+    REQUIRE(lgamma(real128{1}) == 0);
+    real128 x(1);
+    REQUIRE(x.lgamma() == 0);
+    REQUIRE(abs(lgamma(real128{"1.234"}) - real128{"-0.094478407681159572584826666218660204"}) < 1E-34);
 }

--- a/test/real128_trig.cpp
+++ b/test/real128_trig.cpp
@@ -25,3 +25,41 @@ TEST_CASE("real128 sincos")
     REQUIRE(abs(sin(real128{"1.234"}) - real128{"0.943818209374633704861751006156827573"}) < 1E-34);
     REQUIRE(abs(cos(real128{"1.234"}) - real128{"0.330465108071729857403280772789927239"}) < 1E-34);
 }
+
+TEST_CASE("real128 tan")
+{
+    REQUIRE(tan(real128{}) == 0);
+    real128 x;
+    REQUIRE(x.tan() == 0);
+    x = 0;
+    REQUIRE(x.tan() == 0);
+    REQUIRE(abs(tan(real128{"1.234"}) - real128{"2.85602983891954817746307080725818826776"}) < 1E-33);
+}
+
+TEST_CASE("real128 inversefunctions")
+{
+    {
+        REQUIRE(acos(real128{}) == real128_pi() / 2.);
+        real128 x;
+        REQUIRE(x.acos() == real128_pi() / 2.);
+        x = 0;
+        REQUIRE(x.acos() == real128_pi() / 2.);
+        REQUIRE(abs(acos(cos(real128{"0.234"})) - real128{"0.234"}) < 1E-33);
+    }
+    {
+        REQUIRE(asin(real128{}) == 0.);
+        real128 x;
+        REQUIRE(x.asin() == 0.);
+        x = 0;
+        REQUIRE(x.asin() == 0.);
+        REQUIRE(abs(asin(sin(real128{"0.234"})) - real128{"0.234"}) < 1E-33);
+    }
+    {
+        REQUIRE(atan(real128{}) == 0.);
+        real128 x;
+        REQUIRE(x.atan() == 0.);
+        x = 0;
+        REQUIRE(x.atan() == 0.);
+        REQUIRE(abs(atan(tan(real128{"0.234"})) - real128{"0.234"}) < 1E-33);
+    }
+}


### PR DESCRIPTION
real128 was missing some functions (e.g. tan, erf etc..) that are found necessary to answer, for example, to the cancellation issue in https://github.com/darioizzo/audi/issues/29

in this PR tan, inverse trig, erf are added to allow the class to be used to build a quad precision differential algebra (audi)