### PR TITLE
Change MPP_CXX_FLAGS_DEBUG_RELEASE to MPP_CXX_FLAGS_RELEASE for RELEA…

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,7 +28,7 @@ function(ADD_MPPP_BENCHMARK arg1)
     target_compile_options(${arg1} PRIVATE "-DMPPP_BENCHMARK_FLINT")
   endif()
   target_include_directories(${arg1} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-  target_compile_options(${arg1} PRIVATE "$<$<CONFIG:DEBUG>:${MPPP_CXX_FLAGS_DEBUG}>" "$<$<CONFIG:RELEASE>:${MPPP_CXX_FLAGS_DEBUG_RELEASE}>")
+  target_compile_options(${arg1} PRIVATE "$<$<CONFIG:DEBUG>:${MPPP_CXX_FLAGS_DEBUG}>" "$<$<CONFIG:RELEASE>:${MPPP_CXX_FLAGS_RELEASE}>")
   # Let's setup the target C++ standard, but only if the user did not provide it manually.
   if(NOT CMAKE_CXX_STANDARD)
     if(MPPP_COMPILER_SUPPORTS_CONCEPTS)


### PR DESCRIPTION
…SE configuration.

MPP_CXX_FLAGS_DEBUG_RELEASE is nowhere defined and remains empty causing compile errors when using VSC++ because of NOMINMAX not defined.
Benchmarks still don't run but they are compileable.