### PR TITLE
MSVC fixes

### DIFF
--- a/include/mp++/complex.hpp
+++ b/include/mp++/complex.hpp
@@ -3169,7 +3169,7 @@ inline namespace literals
 
 #define MPPP_DECLARE_COMPLEX_UDL(prec)                                                                                 \
     template <char... Chars>                                                                                           \
-    inline complex operator""_icr##prec()                                                                              \
+    inline complex operator"" _icr##prec()                                                                              \
     {                                                                                                                  \
         return complex{real{real_kind::zero, prec}, detail::real_literal_impl<Chars...>(prec)};                        \
     }

--- a/include/mp++/detail/fmt.hpp
+++ b/include/mp++/detail/fmt.hpp
@@ -50,6 +50,8 @@ struct to_string_formatter {
         fmt::throw_format_error("Invalid format");
 #endif
         // LCOV_EXCL_STOP
+
+        return it;
     }
 
     template <typename T, typename FormatContext>

--- a/include/mp++/detail/integer_literals.hpp
+++ b/include/mp++/detail/integer_literals.hpp
@@ -402,7 +402,7 @@ inline namespace literals
 
 #define MPPP_DECLARE_INTEGRAL_UDL(n)                                                                                   \
     template <char... Chars>                                                                                           \
-    inline integer<n> operator""_z##n()                                                                                \
+    inline integer<n> operator"" _z##n()                                                                               \
     {                                                                                                                  \
         return detail::integer_literal_impl<n, Chars...>();                                                            \
     }

--- a/include/mp++/detail/rational_literals.hpp
+++ b/include/mp++/detail/rational_literals.hpp
@@ -18,7 +18,7 @@ inline namespace literals
 
 #define MPPP_DECLARE_RATIONAL_UDL(n)                                                                                   \
     template <char... Chars>                                                                                           \
-    inline rational<n> operator""_q##n()                                                                               \
+    inline rational<n> operator"" _q##n()                                                                              \
     {                                                                                                                  \
         return rational<n>{detail::integer_literal_impl<n, Chars...>()};                                               \
     }

--- a/include/mp++/detail/real_literals.hpp
+++ b/include/mp++/detail/real_literals.hpp
@@ -49,7 +49,7 @@ inline namespace literals
 
 #define MPPP_DECLARE_REAL_UDL(prec)                                                                                    \
     template <char... Chars>                                                                                           \
-    inline real operator""_r##prec()                                                                                   \
+    inline real operator"" _r##prec()                                                                                  \
     {                                                                                                                  \
         return detail::real_literal_impl<Chars...>(prec);                                                              \
     }


### PR DESCRIPTION
I just updated to the latest MPPP and encountered some compilation errors on Windows compiling with Visual Studio 2022 17.9.2:

-  errors like: pasting `'""_z' and '1' does not result in a valid preprocessing token`
- a warning about not all control paths returning a value.