### PR TITLE
libarb is has been rolled into libflint-arb.  CMakeFileList.txt needs to be updated.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,8 @@ endif()
 # Optional dependency on Arb.
 if(MPPP_WITH_ARB)
     find_package(mp++_FLINT REQUIRED)
-    find_package(mp++_Arb REQUIRED)
+    # ARB has been merged into FLINT.
+    # find_package(mp++_Arb REQUIRED)
 
     # Check support for certain Arb functions.
     set(CMAKE_REQUIRED_INCLUDES "${MPPP_ARB_INCLUDE_DIR}")
@@ -374,7 +375,8 @@ if(MPPP_WITH_ARB)
     unset(CMAKE_REQUIRED_INCLUDES)
     unset(CMAKE_REQUIRED_LIBRARIES)
 
-    target_link_libraries(mp++ PRIVATE mp++::Arb mp++::FLINT)
+    #target_link_libraries(mp++ PRIVATE mp++::Arb mp++::FLINT)
+    target_link_libraries(mp++ PRIVATE mp++::FLINT)
     set(MPPP_ENABLE_ARB "#define MPPP_WITH_ARB")
 endif()
 

--- a/src/detail/arb.cpp
+++ b/src/detail/arb.cpp
@@ -23,14 +23,14 @@
 #include <flint/flint.h>
 #include <flint/fmpz.h>
 
-#include <arb.h>
-#include <arb_hypgeom.h>
-#include <arf.h>
-#include <mag.h>
+#include <flint/arb.h>
+#include <flint/arb_hypgeom.h>
+#include <flint/arf.h>
+#include <flint/mag.h>
 
 #if defined(MPPP_WITH_MPC)
 
-#include <acb.h>
+#include <flint/acb.h>
 
 #endif
 


### PR DESCRIPTION
Fixes #311
A quick workaround so that we can compile with flint/arb

Hmm, not sure if this fix works. It went through on my end.